### PR TITLE
handle device renames gracefully in all cases (fixes #3) & improve on/off speed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Dependencies
+node_modules
+
+# IDE
+.idea

--- a/index.js
+++ b/index.js
@@ -38,10 +38,13 @@ VeseyncPlugPlatform.prototype.configureAccessory = function(accessory) {
         this.log("Duplicate accessory detected, removing existing if possible, otherwise removing this accessory", accessoryId);
         try {
             this.removeAccessory(this.accessories[accessoryId], accessoryId);
+            this.setService(accessory);
         } catch (error) {
             this.removeAccessory(accessory, accessoryId);
             accessory = this.accessories[accessoryId];
         }
+    } else {
+        this.setService(accessory);
     }
 
     this.accessories[accessoryId] = accessory;

--- a/index.js
+++ b/index.js
@@ -1,11 +1,7 @@
 "use strict";
 
 let EtekcityClient = require('./lib/client');
-
-let client = new EtekcityClient();
-
-//var vesync = require('./lib/vesync.js');
-var Accessory, Service, Characteristic, UUIDGen;
+let Accessory, Service, Characteristic, UUIDGen;
 
 module.exports = function(homebridge) {
     Accessory = homebridge.platformAccessory;
@@ -14,13 +10,12 @@ module.exports = function(homebridge) {
     UUIDGen = homebridge.hap.uuid;
 
     homebridge.registerPlatform("homebridge-vesync", "VesyncPlug", VeseyncPlugPlatform);
-}
+};
 
 function VeseyncPlugPlatform(log, config, api) {
     this.log = log;
     this.config = config;
-    //    this.plugs = this.config.plugs || [];
-    this.accessories = [];
+    this.accessories = {};
     this.cache_timeout = 10; // seconds
     this.debug = config['debug'] || false;
     this.username = config['username'];
@@ -30,75 +25,78 @@ function VeseyncPlugPlatform(log, config, api) {
         this.api = api;
         this.api.on('didFinishLaunching', this.didFinishLaunching.bind(this));
     }
+
+    this.client = new EtekcityClient(log);
 }
 
 VeseyncPlugPlatform.prototype.configureAccessory = function(accessory) {
-    var accessoryId = accessory.context.id;
-    this.log("configureAccessory");
-    this.setService(accessory);
+    let accessoryId = accessory.context.id;
+    if (this.debug) this.log("configureAccessory: " + accessoryId);
+
+    // Handle rename case. Depending on which order the accessories come back in, we will want to handle them differently below
+    if (this.accessories[accessoryId]) {
+        this.log("Duplicate accessory detected, removing existing if possible, otherwise removing this accessory", accessoryId);
+        try {
+            this.removeAccessory(this.accessories[accessoryId], accessoryId);
+        } catch (error) {
+            this.removeAccessory(accessory, accessoryId);
+            accessory = this.accessories[accessoryId];
+        }
+    }
+
     this.accessories[accessoryId] = accessory;
-}
+};
 
 VeseyncPlugPlatform.prototype.didFinishLaunching = function() {
-    var that = this;
+    let that = this;
 
     this.deviceDiscovery();
-    setInterval(that.devicePolling.bind(that), this.cache_timeout * 1000);
     setInterval(that.deviceDiscovery.bind(that), this.cache_timeout * 6000);
-}
-
-VeseyncPlugPlatform.prototype.devicePolling = function() {
-    /*var me = this;
-
-    // Send a return status message every interval
-    for (var id in this.accessories) {
-        var plug = this.accessories[id];
-        if (me.debug)
-            me.log("Poll:", id, plug.context.name);
-        me.getPowerState(plug, function(err, status) {
-          me.log("Got status: " + status);
-        })
-    }*/
-}
+};
 
 VeseyncPlugPlatform.prototype.deviceDiscovery = function() {
-    var me = this;
+    let me = this;
+    if (me.debug) me.log("DeviceDiscovery invoked");
 
-    // Send a device discovery message every interval
-    if (me.debug)
-        me.log("Sending device discovery message");
-
-    client.login(this.username, this.password).then( () => {
-        return client.getDevices();
+    this.client.login(this.username, this.password).then( () => {
+        return this.client.getDevices();
     }).then( devices => {
-          if (this.debug) this.log("Adding discovered devices");
+        if (me.debug) me.log("Adding discovered devices");
+        for (let i in devices) {
+            let existing = me.accessories[devices[i].id];
 
-          for (var i in devices) {
-              var existing = this.accessories[devices[i].id];
-              if (!existing) {
-                  me.log("Adding:", devices[i].id, devices[i].name);
-                  this.addAccessory(devices[i]);
-              } else {
-                  if (this.debug) me.log("Skipping existing device", i);
-              }
-          }
-          if (devices) {
-              for (var id in this.accessories) {
-                  var found = devices.find( (device) => { return device.id.includes(id); });
-                  if (!found) {
-                      me.log("Not found ", id);
-                      removeAccessory(this.accessories[id]);
-                  }
-              }
-          }
-      if (this.debug) me.log("Discovery complete");
+            if (!existing) {
+                me.log("Adding device: ", devices[i].id, devices[i].name);
+                me.addAccessory(devices[i]);
+            } else {
+                if (me.debug) me.log("Skipping existing device", i);
+            }
+        }
+
+        // Check existing accessories exist in vesync devices
+        if (devices) {
+            for (let index in me.accessories) {
+                var acc = me.accessories[index];
+                var found = devices.find( (device) => { return device.id.includes(index); });
+                if (!found) {
+                    me.log("Previously configured accessory not found, removing", index);
+                    me.removeAccessory(me.accessories[index]);
+                } else if (found.name != acc.context.name) {
+                    me.log("Accessory name does not match device name, got " + found.name + " expected " + acc.context.name);
+                    me.removeAccessory(me.accessories[index]);
+                    me.addAccessory(found);
+                    me.log("Accessory removed & readded!");
+                }
+            }
+        }
+
+        if (me.debug) me.log("Discovery complete");
     });
-}
+};
 
 VeseyncPlugPlatform.prototype.addAccessory = function(data) {
     if (!this.accessories[data.id]) {
-        var uuid = UUIDGen.generate(data.id);
-
+        let uuid = UUIDGen.generate(data.id);
         var newAccessory = new Accessory(data.id, uuid, 8);
 
         newAccessory.context.name = data.name;
@@ -117,17 +115,37 @@ VeseyncPlugPlatform.prototype.addAccessory = function(data) {
     this.getInitState(newAccessory, data);
 
     this.accessories[data.id] = newAccessory;
-}
+};
 
-VeseyncPlugPlatform.prototype.removeAccessory = function(accessory) {
+/**
+ * In some cases the accessory context is undefined, or the accessory is undefined. to keep the code dry, this
+ * is the only method for removing an accessory from the homebridge platform and the plugin accessory context.
+ * 
+ * When the id is already known, it should be passed as the second parameter to ensure both homebridge api and
+ * local accessory context is cleaned up after a device rename/removal. There may be a case where the id needs
+ * to be removed from local context, but is missing from the homebridge api, so I wrapped the
+ * unregisterPlatformAccessories call in a try/catch to avoid crashing before removing from this.accessories 
+ * 
+ * If the accessoryId is not passed in, attempt to find the accessory id from the context. In the case where
+ * the id is still not determined, attempt to remove the device from the homebridge api to avoid crashes. 
+ */
+VeseyncPlugPlatform.prototype.removeAccessory = function(accessory, accessoryId = undefined) {
     if (accessory) {
-        var name = accessory.context.name;
-        var id = accessory.context.id;
-        this.log.warn("Removing VesyncPlug: " + name + ". No longer reachable or configured.");
-        this.api.unregisterPlatformAccessories("homebridge-vesync", "VesyncPlug", [accessory]);
-        delete this.accessories[id];
+        let id = accessoryId !== undefined ? accessoryId : (accessory.context === undefined ? undefined : accessory.context.id);
+        if (this.debug) this.log("Removing accessory", id);
+
+        try {
+            this.api.unregisterPlatformAccessories("homebridge-vesync", "VesyncPlug", [accessory]);
+        } catch (error) {
+            // in case its already been deregistered, don't crash. remove from plugin's accessories context below
+        }
+
+        // Remove from local accessories context if id is defined
+        if (id !== undefined) {
+            delete this.accessories[id];
+        }
     }
-}
+};
 
 VeseyncPlugPlatform.prototype.setService = function(accessory) {
     accessory.getService(Service.Outlet)
@@ -136,10 +154,10 @@ VeseyncPlugPlatform.prototype.setService = function(accessory) {
         .on('get', this.getPowerState.bind(this, accessory.context));
 
     accessory.on('identify', this.identify.bind(this, accessory.context));
-}
+};
 
 VeseyncPlugPlatform.prototype.getInitState = function(accessory, data) {
-    var info = accessory.getService(Service.AccessoryInformation);
+    let info = accessory.getService(Service.AccessoryInformation);
 
     accessory.context.manufacturer = "Etekcity";
     info.setCharacteristic(Characteristic.Manufacturer, accessory.context.manufacturer);
@@ -152,55 +170,55 @@ VeseyncPlugPlatform.prototype.getInitState = function(accessory, data) {
     accessory.getService(Service.Outlet)
         .getCharacteristic(Characteristic.On)
         .getValue();
-}
+};
 
 VeseyncPlugPlatform.prototype.setPowerState = function(thisPlug, powerState, callback) {
-    var that = this;
+    let that = this;
+    if (this.debug) this.log("Sending device status change");
 
-    if (this.debug)
-        this.log("Sending device status change");
-
-    return client.login(this.username, this.password).then( () => {
-        return client.getDevices();
+    return this.client.login(this.username, this.password).then( () => {
+        return this.client.getDevices();
     }).then( devices => {
-      return devices.find( (device) => { return device.name.includes(thisPlug.name); });
+        return devices.find( (device) => { return device.name.includes(thisPlug.name); });
     }).then( (device) => {
         thisPlug.status = device.status;
-        if (this.debug) this.log("Discovery complete");
-        if(device.status == 'open' && powerState == false) {
-          return client.turnOff(device.id);
+        if (device.status == 'open' && powerState == false) {
+            return this.client.turnOff(device.id);
         }
-        if(device.status == 'break' && powerState == true) {
-          return client.turnOn(device.id);
+
+        if (device.status == 'break' && powerState == true) {
+            return this.client.turnOn(device.id);
         }
     }).then( () => {
-      callback();
+        callback();
     }).catch( (err) => {
-      this.log("Failed to set power state to", powerState);
-      callback(err);
-    })
-}
-
+        this.log("Failed to set power state to", powerState);
+        callback(err);
+    });
+};
 
 VeseyncPlugPlatform.prototype.getPowerState = function(thisPlug, callback) {
     if (this.accessories[thisPlug.id]) {
         this.log("Getting Status: %s %s", thisPlug.id, thisPlug.name)
-        if (this.debug) this.log("Sending device status message");
 
-        return client.login(this.username, this.password).then( () => {
-            return client.getDevices();
+        return this.client.login(this.username, this.password).then( () => {
+            return this.client.getDevices();
         }).then( devices => {
-          return devices.find( (device) => { return device.name.includes(thisPlug.name); });
+            return devices.find( (device) => { return device.name.includes(thisPlug.name); });
         }).then( (device) => {
-            thisPlug.status = device.status;
-            if (this.debug) this.log("Discovery complete");
-            callback(null, device.status == 'open');
+            if (typeof device === 'undefined') {
+                if (this.debug) this.log("Removing undefined device", thisPlug.name);
+                this.removeAccessory(thisPlug)
+            } else {
+                thisPlug.status = device.status;
+                if (this.debug) this.log("getPowerState complete");
+                callback(null, device.status == 'open');
+            }
         });
     } else {
         callback(new Error("Device not found"));
     }
-
-}
+};
 
 VeseyncPlugPlatform.prototype.identify = function(thisPlug, paired, callback) {
     this.log("Identify requested for " + thisPlug.name);

--- a/lib/client.js
+++ b/lib/client.js
@@ -2,7 +2,7 @@ let FormData = require('form-data');
 
 module.exports = class EtekCityClient {
 
-    constructor() {
+    constructor(log) {
         const HyperRequest = require('hyper-request');
         this.client = new HyperRequest({
             baseUrl: 'https://server1.vesync.com:4007',
@@ -12,6 +12,7 @@ module.exports = class EtekCityClient {
                 return JSON.parse(data.replace(/\\/g, '').replace('"[', '[').replace(']"', ']'));
             }
         });
+        this.log = log
     }
 
     login(username, password) {

--- a/lib/client.js
+++ b/lib/client.js
@@ -1,9 +1,10 @@
 let FormData = require('form-data');
+let moment = require('moment');
+const HyperRequest = require('hyper-request');
 
 module.exports = class EtekCityClient {
 
     constructor(log) {
-        const HyperRequest = require('hyper-request');
         this.client = new HyperRequest({
             baseUrl: 'https://server1.vesync.com:4007',
             disablePipe: true,
@@ -13,9 +14,15 @@ module.exports = class EtekCityClient {
             }
         });
         this.log = log
+        this.lastLogin = moment('2000-01-01')
     }
 
     login(username, password) {
+        // If token has been set in last 24 hours, don't log in again
+        if (this.lastLogin.isAfter(moment().subtract(24, 'hours'))) {
+            return Promise.resolve();
+        }
+
         let formData = new FormData();
         formData.append('Account', username);
         formData.append('Password', password);
@@ -32,6 +39,7 @@ module.exports = class EtekCityClient {
         }).then((response) => {
             this.token = response.tk;
             this.uniqueId = response.id;
+            this.lastLogin = moment();
         });
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-vesync",
-  "version": "0.9.0",
+  "version": "0.9.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -49,6 +49,11 @@
       "requires": {
         "mime-db": "1.30.0"
       }
+    },
+    "moment": {
+      "version": "2.20.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.20.1.tgz",
+      "integrity": "sha512-Yh9y73JRljxW5QxN08Fner68eFLxM5ynNOAw2LbIB1YAGeQzZT8QFSUvkAz609Zf+IHhhaUxqZK8dG3W/+HEvg=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,8 +19,9 @@
     "homebridge": ">=0.2.0"
   },
   "dependencies": {
+    "form-data": "^2.3.1",
     "hyper-request": "0.1.17",
-    "form-data": "^2.3.1"
+    "moment": "^2.20.1"
   },
   "keywords": [
     "siri",


### PR DESCRIPTION
I had the same issue (#3) after renaming a device. I checked out PR #4, however there is a scoping error. There are also cases that were not covered in that fix; I have fixed and tested the following cases:

- Homebridge stopped, device is rename, homebridge starts
- Homebridge is running while device is renamed, device discovery is invoked
- Homebridge is running while device is renamed, get power state is invoked (this is the only case in #4)

Additionally, I updated the client to only hit the login endpoint for a new token every 24 hours; decreasing the time it takes to toggle my lights on/off. I also fixed some indentation that was off and added some documentation to the `removeAccessory` method.